### PR TITLE
chore: bump pnpm to 9.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "tailwindcss": "^3.4.6",
     "typescript": "^5.5.3"
   },
-  "packageManager": "pnpm@9.4.0",
+  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e",
   "engines": {
     "node": ">=20.14.0",
-    "pnpm": "9.4.0",
+    "pnpm": "9.6.0",
     "npm": "please use pnpm",
     "yarn": "please use pnpm"
   }


### PR DESCRIPTION
![Screenshot 2024-07-23 at 13-35-57 build-web-ui-0b316c8build-chorus-web-ui-7vb4l _ argo _ Workflows - Argo](https://github.com/user-attachments/assets/0f7d9b30-a721-4e7b-adaa-5956da5fb455)
