### PR TITLE
fix: remove java.Dockerfile

### DIFF
--- a/.devcontainer/java.Dockerfile
+++ b/.devcontainer/java.Dockerfile
@@ -1,9 +1,0 @@
-FROM registry.itrcs3-app.intranet.chuv/ds-ubuntu:latest
-
-USER root
-
-RUN apt-get update && \
-    apt-get install -y python3 python3-pip unzip default-jre libpq-dev
-
-
-ENV SHELL /bin/bash


### PR DESCRIPTION
Likely unused, as it's not using anything publicly available.

Signed-off-by: Yoan Blanc <yoan.blanc@chuv.ch>
